### PR TITLE
Added null check for geoInfo in setting statusText

### DIFF
--- a/geo_ip_lite.js
+++ b/geo_ip_lite.js
@@ -110,7 +110,7 @@ module.exports = function(RED) {
                 return;
             }
             
-            var statusText = "country " + geoInfo.country + " (" + geoInfo.region + ")";
+            var statusText = (geoInfo !== null) ? "country " + geoInfo.country + " (" + geoInfo.region + ")" : "Private or Invalid IP";
             node.status({fill:"blue",shape:"dot",text:statusText});
             
             node.send(msg);   


### PR DESCRIPTION
Submitting an IP address in the private range results in geoInfo being returned null.  This caused an error when setting the statusText on Line 113.  Modified the code to set a default statusText of "Private or Invalid IP" when geoInfo is null